### PR TITLE
Add support for WSL 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ const isWsl = () => {
 		return false;
 	}
 
-	if (os.release().toLocaleLowerCase().includes('microsoft')) {
+	if (os.release().toLowerCase().includes('microsoft')) {
 		return true;
 	}
 
 	try {
-		if (fs.readFileSync('/proc/version', 'utf8').toLocaleLowerCase().includes('microsoft')) {
+		if (fs.readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft')) {
 			return true;
 		}
 	} catch (_) {

--- a/index.js
+++ b/index.js
@@ -4,18 +4,15 @@ const fs = require('fs');
 
 const isWsl = () => {
 	if (process.platform !== 'linux') {
-		console.log('NOT LINUX');
 		return false;
 	}
 
 	if (os.release().toLocaleLowerCase().includes('microsoft')) {
-		console.log('RELEASE');
 		return true;
 	}
 
 	try {
 		if (fs.readFileSync('/proc/version', 'utf8').toLocaleLowerCase().includes('microsoft')) {
-			console.log('VERSION');
 			return true;
 		}
 	} catch (_) {

--- a/index.js
+++ b/index.js
@@ -13,11 +13,13 @@ const isWsl = () => {
 		return true;
 	}
 
-	if (fs.readFileSync('/proc/version', 'utf8').match(MS_RE) !== null) {
-		return true;
+	try {
+		if (fs.readFileSync('/proc/version', 'utf8').match(MS_RE) !== null) {
+			return true;
+		}
+	} catch (_) {
+		return false;
 	}
-
-	return false;
 };
 
 module.exports = isWsl;

--- a/index.js
+++ b/index.js
@@ -2,19 +2,20 @@
 const os = require('os');
 const fs = require('fs');
 
-const MS_RE = /microsoft/i;
-
 const isWsl = () => {
 	if (process.platform !== 'linux') {
+		console.log('NOT LINUX');
 		return false;
 	}
 
-	if (os.release().match(MS_RE) !== null) {
+	if (os.release().toLocaleLowerCase().includes('microsoft')) {
+		console.log('RELEASE');
 		return true;
 	}
 
 	try {
-		if (fs.readFileSync('/proc/version', 'utf8').match(MS_RE) !== null) {
+		if (fs.readFileSync('/proc/version', 'utf8').toLocaleLowerCase().includes('microsoft')) {
+			console.log('VERSION');
 			return true;
 		}
 	} catch (_) {
@@ -22,4 +23,8 @@ const isWsl = () => {
 	}
 };
 
-module.exports = isWsl;
+if (process.env.__IS_WSL_TEST__) {
+	module.exports = isWsl;
+} else {
+	module.exports = isWsl();
+}

--- a/index.js
+++ b/index.js
@@ -2,24 +2,22 @@
 const os = require('os');
 const fs = require('fs');
 
+const MS_RE = /microsoft/i;
+
 const isWsl = () => {
 	if (process.platform !== 'linux') {
 		return false;
 	}
 
-	if (os.release().includes('Microsoft')) {
+	if (os.release().match(MS_RE) !== null) {
 		return true;
 	}
 
-	try {
-		return fs.readFileSync('/proc/version', 'utf8').includes('Microsoft');
-	} catch (_) {
-		return false;
+	if (fs.readFileSync('/proc/version', 'utf8').match(MS_RE) !== null) {
+		return true;
 	}
+
+	return false;
 };
 
-if (process.env.__IS_WSL_TEST__) {
-	module.exports = isWsl;
-} else {
-	module.exports = isWsl();
-}
+module.exports = isWsl;

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 > Check if the process is running inside [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about) (Bash on Windows)
 
-Can be useful if you need to work around unimplemented or buggy features in WSL.
+Can be useful if you need to work around unimplemented or buggy features in WSL. Supports both WSL 1 and WSL 2.
 
 
 ## Install

--- a/test.js
+++ b/test.js
@@ -7,7 +7,9 @@ test.beforeEach(() => {
 });
 
 test('inside WSL 1', t => {
-	const origPlatform = process.platform;
+	process.env.__IS_WSL_TEST__ = true;
+
+	const originalPlatform = process.platform;
 	Object.defineProperty(process, 'platform', {value: 'linux'});
 
 	const isWsl = proxyquire('.', {
@@ -18,11 +20,14 @@ test('inside WSL 1', t => {
 
 	t.true(isWsl());
 
-	Object.defineProperty(process, 'platform', {value: origPlatform});
+	delete process.env.__IS_WSL_TEST__;
+	Object.defineProperty(process, 'platform', {value: originalPlatform});
 });
 
 test('inside WSL 2', t => {
-	const origPlatform = process.platform;
+	process.env.__IS_WSL_TEST__ = true;
+
+	const originalPlatform = process.platform;
 	Object.defineProperty(process, 'platform', {value: 'linux'});
 
 	const isWsl = proxyquire('.', {
@@ -33,15 +38,19 @@ test('inside WSL 2', t => {
 
 	t.true(isWsl());
 
-	Object.defineProperty(process, 'platform', {value: origPlatform});
+	delete process.env.__IS_WSL_TEST__;
+	Object.defineProperty(process, 'platform', {value: originalPlatform});
 });
 
 test('not inside WSL', t => {
-	const origPlatform = process.platform;
+	process.env.__IS_WSL_TEST__ = true;
+
+	const originalPlatform = process.platform;
 	Object.defineProperty(process, 'platform', {value: 'darwin'});
 
 	const isWsl = require('.');
 	t.false(isWsl());
 
-	Object.defineProperty(process, 'platform', {value: origPlatform});
+	delete process.env.__IS_WSL_TEST__;
+	Object.defineProperty(process, 'platform', {value: originalPlatform});
 });

--- a/test.js
+++ b/test.js
@@ -6,9 +6,7 @@ test.beforeEach(() => {
 	clearModule('.');
 });
 
-test('inside WSL', t => {
-	process.env.__IS_WSL_TEST__ = true;
-
+test('inside WSL 1', t => {
 	const origPlatform = process.platform;
 	Object.defineProperty(process, 'platform', {value: 'linux'});
 
@@ -20,10 +18,30 @@ test('inside WSL', t => {
 
 	t.true(isWsl());
 
-	delete process.env.__IS_WSL_TEST__;
+	Object.defineProperty(process, 'platform', {value: origPlatform});
+});
+
+test('inside WSL 2', t => {
+	const origPlatform = process.platform;
+	Object.defineProperty(process, 'platform', {value: 'linux'});
+
+	const isWsl = proxyquire('.', {
+		fs: {
+			readFileSync: () => 'Linux version 4.19.43-microsoft-standard (oe-user@oe-host) (gcc version 7.3.0 (GCC)) #1 SMP Mon May 20 19:35:22 UTC 2019'
+		}
+	});
+
+	t.true(isWsl());
+
 	Object.defineProperty(process, 'platform', {value: origPlatform});
 });
 
 test('not inside WSL', t => {
-	t.false(require('.'));
+	const origPlatform = process.platform;
+	Object.defineProperty(process, 'platform', {value: 'darwin'});
+
+	const isWsl = require('.');
+	t.false(isWsl());
+
+	Object.defineProperty(process, 'platform', {value: origPlatform});
 });


### PR DESCRIPTION
Hey there, WSL 2 was initially released and your package does not detect it. In WSL 2, there is lowercase `microsoft` sub string in os query, so your detection technique in not sufficient anymore. 
Also, your trickery with `__IS_WSL_TEST__` env flag is not needed, because `process.platform` is not leaking to testable module - it's not portable and stable. Safer and easier just to export function and do env trickery inside test module.