### PR TITLE
Replacing is-docker with is-inside-container

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import process from 'node:process';
 import os from 'node:os';
 import fs from 'node:fs';
-import isDocker from 'is-docker';
+import isInsideContainer from 'is-inside-container';
 
 const isWsl = () => {
 	if (process.platform !== 'linux') {
@@ -9,7 +9,7 @@ const isWsl = () => {
 	}
 
 	if (os.release().toLowerCase().includes('microsoft')) {
-		if (isDocker()) {
+		if (isInsideContainer()) {
 			return false;
 		}
 
@@ -18,7 +18,7 @@ const isWsl = () => {
 
 	try {
 		return fs.readFileSync('/proc/version', 'utf8').toLowerCase().includes('microsoft')
-			? !isDocker() : false;
+			? !isInsideContainer() : false;
 	} catch {
 		return false;
 	}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"is"
 	],
 	"dependencies": {
-		"is-docker": "^3.0.0"
+		"is-inside-container": "^1.0.0"
 	},
 	"devDependencies": {
 		"ava": "^5.3.1",

--- a/test.js
+++ b/test.js
@@ -75,7 +75,7 @@ test('not inside WSL, but inside Linux', async t => {
 	Object.defineProperty(process, 'platform', {value: originalPlatform});
 });
 
-test('inside WSL, but inside docker', async t => {
+test('inside WSL, but inside container', async t => {
 	process.env.__IS_WSL_TEST__ = true;
 
 	const originalPlatform = process.platform;
@@ -85,7 +85,7 @@ test('inside WSL, but inside docker', async t => {
 		fs: {
 			readFileSync: () => 'Linux version 4.19.43-microsoft-standard (oe-user@oe-host) (gcc version 7.3.0 (GCC)) #1 SMP Mon May 20 19:35:22 UTC 2019',
 		},
-		'is-docker': () => true,
+		'is-inside-container': () => true,
 		os: {
 			release: () => 'microsoft',
 		},


### PR DESCRIPTION
Using is-inside-container to cover the case when running a podman container from inside WSL.