### PR TITLE
Add `DISABLE_IS_WSL` as an escape hatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import fs from 'node:fs';
 import isInsideContainer from 'is-inside-container';
 
 const isWsl = () => {
-	if (process.platform !== 'linux') {
+	if (process.platform !== 'linux' || process.env.DISABLE_IS_WSL) {
 		return false;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -19,3 +19,21 @@ import isWsl from 'is-wsl';
 console.log(isWsl);
 //=> true
 ```
+
+### Disable `is-wsl`
+
+Some tools break when trying to use binaries outside WSL.
+In these cases you can disable `is-wsl` by setting the `DISABLE_IS_WSL`
+environment variable.
+
+```sh
+DISABLE_IS_WSL=true
+```
+
+```js
+import isWsl from 'is-wsl';
+
+// When running inside Windows Subsystem for Linux
+console.log(isWsl);
+//=> false
+```

--- a/test.js
+++ b/test.js
@@ -96,3 +96,23 @@ test('inside WSL, but inside container', async t => {
 	delete process.env.__IS_WSL_TEST__;
 	Object.defineProperty(process, 'platform', {value: originalPlatform});
 });
+
+test('inside WSL, but DISABLE_IS_WSL is set', async t => {
+	process.env.__IS_WSL_TEST__ = true;
+	process.env.DISABLE_IS_WSL = true;
+
+	const originalPlatform = process.platform;
+	Object.defineProperty(process, 'platform', {value: 'linux'});
+
+	const isWsl = await esmock('./index.js', {
+		fs: {
+			readFileSync: () => 'Linux version 4.19.43-microsoft-standard (oe-user@oe-host) (gcc version 7.3.0 (GCC)) #1 SMP Mon May 20 19:35:22 UTC 2019',
+		},
+	});
+
+	t.false(isWsl());
+
+	delete process.env.__IS_WSL_TEST__;
+	delete process.env.DISABLE_IS_WSL;
+	Object.defineProperty(process, 'platform', {value: originalPlatform});
+});


### PR DESCRIPTION
Currently there is no way to to disable `is-wsl`, which leads to undesired effects with tools consuming `is-wsl`. As an example the Web Test Runner will try to use the Chrome binary from Windows, even when Chrome is installed in WSL.

This PR introduces usage of the environment variable `DISABLE_IS_WSL` to disable the `is-wsl` functionality. This allows consumers of downstream tools to prevent undesired calls to Windows binaries as an opt-in.